### PR TITLE
update CATEGORY_ARGUMENT value

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -23,7 +23,7 @@ const TELL_FACT = 'tell.fact';
 const TELL_CAT_FACT = 'tell.cat.fact';
 
 // API.AI parameter names
-const CATEGORY_ARGUMENT = 'category';
+const CATEGORY_ARGUMENT = 'fact-category';
 
 // API.AI Contexts/lifespans
 const FACTS_CONTEXT = 'choose_fact-followup';


### PR DESCRIPTION
I updated the value of CATEGORY_ARGUMENT to 'fact-category' because when following the facts about google how-to video with api.ai. The parameter is named 'fact-category'. If you just follow the video and then deploy the function with firebase and link the tell.fact intent with the webhook given. It will always run the default fallback intent instead of the logic since 'category' isn't the parameter used in the how-to video. But when you update CATEGORY_ARGUMENT to 'fact-category' and deploy function and use the webhook. The code runs as shown in the how-to video & as shown in factsAboutGoogle function since it matches the parameter used in the how-to video