### PR TITLE
[Enhancement] Add ngrok (optional) for improved local development 

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -5,13 +5,19 @@
   "private": true,
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
+  "config" : {
+    "port" : "5000"
+  },
   "engines": {
     "node": "~4.2"
   },
   "scripts": {
     "lint": "eslint --fix \"**/*.js\"",
     "test": "npm run lint",
-    "start": "firebase serve --only functions",
+    "serve": "firebase serve --only functions",
+    "start": "npm run serve",
+    "tunnel": "ngrok http $npm_package_config_port",
+    "start:tunnel": "stmux -M -- [ [ -s 1/2 \"npm run tunnel\" ] : \"npm run serve -- --port $npm_package_config_port\" ]",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log"
   },
@@ -30,5 +36,9 @@
     "eslint-plugin-node": "^5.0.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1"
+  },
+  "optionalDependencies": {
+    "ngrok": "^2.2.22",
+    "stmux": "^1.4.18"
   }
 }


### PR DESCRIPTION
## Summary
This PR adds the command `start:tunnel` to provide a valid `https` fulfillment Function URL via `ngrok` while running the skill locally.

## Background
During local skill development, it is not uncommon to run `ngrok http 5000` in combination with `firebase serve --only functions` or `npm start`, in order to test out fulfillment webhooks.

Other examples like [actionssdk-smart-home-nodejs](https://github.com/actions-on-google/actionssdk-smart-home-nodejs) provide documentation on running a skill either locally or hosted, but this skill documentation suggests that developers will run `firebase deploy --only functions` once and be done.

Since [actionssdk-smart-home-nodejs depends on `ngrok`](https://github.com/actions-on-google/actionssdk-smart-home-nodejs/blob/8366a7bf290cf9ca69adac044c8131c187d31372/smart-home-provider/package.json#L24) for exposing endpoints locally, I think it would be worth considering including `ngrok` as an optional dependency for this skill.  Running `stmux` allows us to see the output for both `ngrok` and `firebase` running in parallel.

## Changes
+ `ngrok` and `stmux` to `package.json` as optional dependencies
+ default port to`package.json`
+ new commands `start:tunnel` and `tunnel`

## Demo
```sh
$ npm run start:tunnel
```
![Demo of Multi-Display](http://dl.dropbox.com/s/7fslbdt507c6k80/Screenshot%202017-09-26%2023.37.58.png)

### Possible Future Work
- [ ] Update documentation for showing how to add a local webhook url in the form `https://<NGROK_DOMAIN>.ngrok.io/${PROJECT}/${REGION}/myApp`
- [ ] Include setup notes from [`stmux`](https://www.npmjs.com/package/stmux#notice)
